### PR TITLE
feat: implement Result pattern for standardized API responses

### DIFF
--- a/src/PBC.SystemConfiguration.API/Helpers/ResponseHelper.cs
+++ b/src/PBC.SystemConfiguration.API/Helpers/ResponseHelper.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using PBC.SystemConfiguration.Application.Dtos.Common;
+using PBC.SystemConfiguration.Application.Extensions;
+using PBC.SystemConfiguration.Domain.Enums;
+
+namespace PBC.SystemConfiguration.API.Helpers;
+
+/// <summary>
+/// Helper class for creating consistent API responses.
+/// </summary>
+public static class ResponseHelper
+{
+    /// <summary>
+    /// Creates a standardized API response with the given parameters.
+    /// </summary>
+    /// <typeparam name="T">The type of the data included in the response.</typeparam>
+    /// <param name="statusCode">HTTP status code for the response.</param>
+    /// <param name="message">message describing the result.</param>
+    /// <param name="isSuccess">Indicates whether the response represents a successful operation.</param>
+    /// <param name="data">The data to include in the response, if any.</param>
+    /// <returns>An IActionResult containing the response.</returns>
+    public static IActionResult CreateResponse<T>(
+        int statusCode,
+        string message,
+        bool isSuccess,
+        T? data = default
+    )
+    {
+        var response = new Response<T>(statusCode, message, isSuccess, data);
+        return new ObjectResult(response) { StatusCode = statusCode };
+    }
+
+    /// <summary>
+    /// Creates a success response with the provided data and optional messages.
+    /// </summary>
+    /// <typeparam name="T">The type of the data included in the response.</typeparam>
+    /// <param name="data">The data to include in the response.</param>
+    /// <param name="message">message describing the success.</param>
+    /// <returns>An IActionResult containing the success response.</returns>
+    public static IActionResult CreateSuccessResponse<T>(
+        T? data,
+        string? message = null
+    )
+    {
+        message ??= ResultEnum.Success.GetDescription();
+        return CreateResponse(200, message, true, data);
+    }
+
+    /// <summary>
+    /// Creates an error response with the provided status code and messages.
+    /// </summary>
+    /// <typeparam name="T">The type of the data (usually null in case of errors).</typeparam>
+    /// <param name="statusCode">HTTP status code representing the error.</param>
+    /// <param name="message">describing the error.</param>
+    /// <returns>An IActionResult containing the error response.</returns>
+    public static IActionResult CreateErrorResponse<T>(
+        int statusCode,
+        string message
+    )
+    {
+        return CreateResponse<T>(statusCode, message, false);
+    }
+}

--- a/src/PBC.SystemConfiguration.API/PBC.SystemConfiguration.API.csproj
+++ b/src/PBC.SystemConfiguration.API/PBC.SystemConfiguration.API.csproj
@@ -17,6 +17,8 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\PBC.SystemConfiguration.Application\PBC.SystemConfiguration.Application.csproj" />
+      <ProjectReference Include="..\PBC.SystemConfiguration.Domain\PBC.SystemConfiguration.Domain.csproj" />
       <ProjectReference Include="..\PBC.SystemConfiguration.Infrastructure\PBC.SystemConfiguration.Infrastructure.csproj" />
     </ItemGroup>
 

--- a/src/PBC.SystemConfiguration.Application/Dtos/Common/Response.cs
+++ b/src/PBC.SystemConfiguration.Application/Dtos/Common/Response.cs
@@ -1,0 +1,11 @@
+﻿using PBC.SystemConfiguration.Application.Interfaces;
+
+namespace PBC.SystemConfiguration.Application.Dtos.Common;
+
+public class Response<T>(int statusCode, string message, bool isSuccess, T data) : IResponse<T>
+{
+    public int StatusCode { get; set; } = statusCode;
+    public string Message { get; set; } = message;
+    public bool IsSuccess { get; set; } = isSuccess;
+    public T Data { get; set; } = data;
+}

--- a/src/PBC.SystemConfiguration.Application/Extensions/EnumExtension.cs
+++ b/src/PBC.SystemConfiguration.Application/Extensions/EnumExtension.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+using System.Reflection;
+
+namespace PBC.SystemConfiguration.Application.Extensions;
+
+public static class EnumExtension
+{
+    public static string GetDescription(this Enum value)
+    {
+        var field = value.GetType().GetField(value.ToString());
+        var attribute = field?.GetCustomAttribute<DescriptionAttribute>();
+        return attribute?.Description ?? value.ToString();
+    }
+}

--- a/src/PBC.SystemConfiguration.Application/Interfaces/IResponse.cs
+++ b/src/PBC.SystemConfiguration.Application/Interfaces/IResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace PBC.SystemConfiguration.Application.Interfaces;
+
+public interface IResponse<T>
+{
+    public int StatusCode { get; set; }
+    public string Message { get; set; }
+    public bool IsSuccess { get; set; }
+    public T Data { get; set; }
+}

--- a/src/PBC.SystemConfiguration.Application/PBC.SystemConfiguration.Application.csproj
+++ b/src/PBC.SystemConfiguration.Application/PBC.SystemConfiguration.Application.csproj
@@ -7,8 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <Folder Include="Dtos\" />
-      <Folder Include="Interfaces\" />
       <Folder Include="Services\" />
     </ItemGroup>
 

--- a/src/PBC.SystemConfiguration.Domain/Enums/ResultEnum.cs
+++ b/src/PBC.SystemConfiguration.Domain/Enums/ResultEnum.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+
+namespace PBC.SystemConfiguration.Domain.Enums;
+
+public enum ResultEnum
+{
+    [Description("Successful")]
+    Success,
+    
+    [Description("Created successfully")] 
+    CreatedSuccessfully,  
+    
+    [Description("Updated successfully")]
+    UpdatedSuccessfully,
+    
+    [Description("Deleted successfully")]
+    DeletedSuccessfully,
+    
+    [Description("Unexpected error")]
+    UnexpectedError,
+}


### PR DESCRIPTION
Introduced a standardized Result pattern to handle API responses consistently across the application. This includes the implementation of the response wrapper, status enums, and helper extensions.

Changes:
- Added `IResponse<T>` interface and `Response<T>` implementation in Application layer.
- Added `ResultEnum` for standardized status messages.
- Implemented `EnumExtension` to retrieve descriptions from enums.
- Created `ResponseHelper` in API layer to simplify `IActionResult` creation.

Closes #3